### PR TITLE
remove `routerChainId` params

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: false,
     es2021: true,
+    node: true,
   },
   extends: [
     'eslint:recommended',
@@ -29,6 +30,7 @@ module.exports = {
       exports: 'always-multiline',
       functions: 'only-multiline',
     }],
+    '@typescript-eslint/member-delimiter-style': 2,
 
     /* ---------- turn off ---------- */
     '@typescript-eslint/no-extra-semi': 0,

--- a/README.md
+++ b/README.md
@@ -89,43 +89,44 @@ POST /relay
 ```
 
 ### `/shouldRouteXcm`
-checks if the relayer can relay and route this request
+checks if the relayer can relay and route this request, returns router address and it's chainId
 ```
 GET /shouldRouteXcm
 params: {
   destParaId: string,     // destination parachain id in number
   dest: string,           // xcm encoded dest in hex
   originAsset: string,    // original address without padding 0s in hex
-  routerChainId: string,  // 10 (acala) or 11 (karura)
 }
 ```
 
 example
 ```
 # ---------- when should route ---------- #
-GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&routerChainId=11&destParaId=2090&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaa37f
-=> {"shouldRoute":true,"routerAddr":"0x8341Cd8b7bd360461fe3ce01422fE3E24628262F","msg":""}
+GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&destParaId=2090&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaa37f
+=>
+{
+  shouldRoute: true,
+  routerAddr: "0x8341Cd8b7bd360461fe3ce01422fE3E24628262F",
+  routerChainId: 11,
+  msg: "",
+}
 
 # ---------- when should not route ---------- #
-GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&routerChainId=9&destParaId=2090&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaa37f
-=> {"shouldRoute":false,"routerAddr":"0x","msg":"unsupported router chainId: 9"}
-
-GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&routerChainId=11&destParaId=1111&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaa37f
+GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&destParaId=1111&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaa37f
 => {"shouldRoute":false,"routerAddr":"0x","msg":"unsupported dest parachain: 1111"}
 
-GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&routerChainId=11&destParaId=2090&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaaaaa
+GET /shouldRouteXcm?dest=0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d&destParaId=2090&originAddr=0x07865c6e87b9f70255377e024ace6630c1eaaaaa
 => {"shouldRoute":false,"routerAddr":"0x","msg":"unsupported token on dest parachin 2090. Token origin address: 0x07865c6e87b9f70255377e024ace6630c1eaaaaa"}
 ```
 
 ### `/routeXcm`
-route this request, returns the transaction receipt
+route this request, and returns the transaction hash
 ```
 POST /routeXcm
 data: {
   destParaId: string,     // destination parachain id
   dest: string,           // xcm encoded dest
   originAsset: string,    // original address without padding 0s
-  routerChainId: string,  // acala (10) or karura (11)
 }
 ```
 
@@ -136,7 +137,6 @@ POST /routeXcm
   destParaId: "2090",
   dest: "0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
   originAsset: "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
-  routerChainId: "11",
 }
 
 => tx hash
@@ -144,14 +144,13 @@ POST /routeXcm
 ```
 
 ### `/relayAndRoute`
-relay from wormhole, and route token to target chain, and returns the transaction receipt for the \*route\* (not relay)
+relay from wormhole, and route token to target chain, and returns transaction hashes
 ```
 POST /relayAndRoute
 data: {
   destParaId: string,     // destination parachain id
   dest: string,           // xcm encoded dest
   originAsset: string,    // original address without padding 0s
-  routerChainId: string,  // acala (10) or karura (11)
   signedVAA: string,      // hex encoded string
 }
 ```
@@ -163,12 +162,14 @@ POST /routeXcm
   destParaId: "2090",
   dest: "0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
   originAsset: "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
-  routerChainId: "11",
   signedVAA: 010000000001007b98257f6bf142c480a0b63ee571374fff5fe4dcd3127977af6860ce516b58084b137c40f913f8d7ca450d5413d619ba85104fbcb0a8a44e4db509faa4ef06d601622af226fd4d000000040000000000000000000000009dcf9d205c9de35334d646bee44b2d2859712a09000000000000011e0f0100000000000000000000000000000000000000000000000000000000000f4240000000000000000000000000337610d27c682e347c9cd60bd4b3b107c9d34ddd0004000000000000000000000000e3234f433914d4cfcf846491ec5a7831ab9f0bb3000b0000000000000000000000000000000000000000000000000000000000000000
 }
 
-=> tx hash
-0xd3b5cbdbc0b8026e7de085b80f0923cf0c92c96f788d702635383c26b8c070c9
+=> tx hashes
+[
+  0xb292b872fb7ddd33de25b0a7ee66e65bac918ec1ab0a6d93446f3dde7435955b,   // relay
+  0xd3b5cbdbc0b8026e7de085b80f0923cf0c92c96f788d702635383c26b8c070c9    // xcm
+]
 ```
 
 ## Tests

--- a/src/__tests__/route.test.ts
+++ b/src/__tests__/route.test.ts
@@ -23,6 +23,11 @@ import { BASILISK_PARA_ID } from '../consts';
 const KARURA_NODE_URL = 'wss://karura-testnet.aca-staging.network/rpc/karura/ws';
 const TEST_KEY = 'efb03e3f4fd8b3d7f9b14de6c6fb95044e2321d6bcb9dfe287ba987920254044';
 
+const encodeXcmDest = (data: any) => {
+  // TODO: use api to encode
+  return '0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+};
+
 const mockXcmToRouter = async (routerAddr: string, signer: Wallet) => {
   const usdc = new ERC20__factory(signer).attach(KARURA_USDC_ADDRESS);
 
@@ -39,7 +44,18 @@ describe('/routeXcm', () => {
   const shouldRouteXcm = (params: any) => axios.get(SHOULD_ROUTE_XCM_URL, { params });
   const routeXcm = (params: RouteParamsXcm) => axios.post(ROUTE_XCM_URL, params);
 
-  const dest = '0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+  const destAddr = 'bXmPf7DcVmFuHEmzH3UX8t6AUkfNQW8pnTeXGhFhqbfngjAak';
+  const dest = encodeXcmDest({
+    V3: {
+      parents: 1,
+      interior: {
+        X2: [
+          { parachain: 2090 },
+          { accountId32: destAddr },
+        ],
+      },
+    },
+  });
 
   const provider = new EvmRpcProvider(KARURA_NODE_URL);
 
@@ -54,7 +70,6 @@ describe('/routeXcm', () => {
   it('when should route', async () => {
     const routeArgs = {
       dest,
-      routerChainId: '11',
       destParaId: BASILISK_PARA_ID,
       originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
     };
@@ -69,17 +84,10 @@ describe('/routeXcm', () => {
     console.log('routing ...');
     const routeRes = await routeXcm(routeArgs);
     console.log(`route finished! txHash: ${routeRes.data}`);
-
-    await provider.disconnect();
   });
 
   // describe.skip('when should not route', () => {})
 });
-
-const encodeXcmDest = (data: any) => {
-  // TODO: use api to encode
-  return '0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
-};
 
 describe.only('/relayAndRoute', () => {
   const shouldRouteXcm = (params: any) => axios.get(SHOULD_ROUTE_XCM_URL, { params });
@@ -122,7 +130,6 @@ describe.only('/relayAndRoute', () => {
   it('when should route', async () => {
     const routeArgs = {
       dest,
-      routerChainId: '11',
       destParaId: BASILISK_PARA_ID,
       originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
     };

--- a/src/__tests__/shouldRoute.test.ts
+++ b/src/__tests__/shouldRoute.test.ts
@@ -10,32 +10,34 @@ describe('/shouldRouteXcm', () => {
   const dest = '0x03010200a9200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
 
   it('when should route', async () => {
-    for (const [routerChainId, supportedChains] of Object.entries(ROUTE_SUPPORTED_CHAINS_AND_ASSETS)) {
-      for (const [destParaId, supportedTokens] of Object.entries(supportedChains)) {
-        for (const tokenAddr of supportedTokens) {
-          let res = await shouldRouteXcm({
-            dest,
-            routerChainId,
-            destParaId,
-            originAddr: tokenAddr,
-          });
+    for (const [destParaId, supportedTokens] of Object.entries(ROUTE_SUPPORTED_CHAINS_AND_ASSETS)) {
+      for (const tokenAddr of supportedTokens) {
+        let res = await shouldRouteXcm({
+          dest,
+          destParaId,
+          originAddr: tokenAddr,
+        });
 
-          expect(res.data.shouldRoute).to.equal(true);
-          expect(res.data.msg).to.equal('');
-          expect(res.data.routerAddr).to.equal('0x8341Cd8b7bd360461fe3ce01422fE3E24628262F');
+        expect(res.data).to.deep.eq({
+          shouldRoute: true,
+          routerAddr: '0x8341Cd8b7bd360461fe3ce01422fE3E24628262F',
+          routerChainId: 11,
+          msg: '',
+        });
 
-          // should be case insensitive
-          res = await shouldRouteXcm({
-            dest,
-            routerChainId: routerChainId,
-            destParaId,
-            originAddr: tokenAddr.toUpperCase(),
-          });
+        // should be case insensitive
+        res = await shouldRouteXcm({
+          dest,
+          destParaId,
+          originAddr: tokenAddr.toUpperCase(),
+        });
 
-          expect(res.data.shouldRoute).to.equal(true);
-          expect(res.data.msg).to.equal('');
-          expect(res.data.routerAddr).to.equal('0x8341Cd8b7bd360461fe3ce01422fE3E24628262F');
-        }
+        expect(res.data).to.deep.eq({
+          shouldRoute: true,
+          routerAddr: '0x8341Cd8b7bd360461fe3ce01422fE3E24628262F',
+          routerChainId: 11,
+          msg: '',
+        });
       }
     }
   });
@@ -43,7 +45,6 @@ describe('/shouldRouteXcm', () => {
   describe('when should not route', () => {
     it('when missing params', async () => {
       let res = await shouldRouteXcm({
-        routerChainId: 11,
         destParaId: BASILISK_PARA_ID,
         originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
       });
@@ -52,15 +53,6 @@ describe('/shouldRouteXcm', () => {
 
       res = await shouldRouteXcm({
         dest,
-        destParaId: BASILISK_PARA_ID,
-        originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
-      });
-      expect(res.data.shouldRoute).to.equal(false);
-      expect(res.data.msg).to.contain('routerChainId is a required field');
-
-      res = await shouldRouteXcm({
-        dest,
-        routerChainId: 11,
         originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
       });
       expect(res.data.shouldRoute).to.equal(false);
@@ -68,7 +60,6 @@ describe('/shouldRouteXcm', () => {
 
       res = await shouldRouteXcm({
         dest,
-        routerChainId: 11,
         destParaId: BASILISK_PARA_ID,
       });
       expect(res.data.shouldRoute).to.equal(false);
@@ -78,19 +69,11 @@ describe('/shouldRouteXcm', () => {
     it('when wrong params', async () => {
       const validArgs = {
         dest,
-        routerChainId: 11,
         destParaId: BASILISK_PARA_ID,
         originAddr: '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
       };
 
       let res = await shouldRouteXcm({
-        ...validArgs,
-        routerChainId: 8,
-      });
-      expect(res.data.shouldRoute).to.equal(false);
-      expect(res.data.msg).to.contain('unsupported router chainId: 8');
-
-      res = await shouldRouteXcm({
         ...validArgs,
         destParaId: 1111,
       });

--- a/src/configureEnv.ts
+++ b/src/configureEnv.ts
@@ -86,6 +86,6 @@ function configAcala(): ChainConfigInfo {
 
 const env: RelayerEnvironment = validateEnvironment();
 
-export const getChainConfigInfo = (chainId: number): ChainConfigInfo | undefined => (
+export const getChainConfigInfo = (chainId: ChainId): ChainConfigInfo | undefined => (
   env.supportedChains.find((x) => x.chainId === chainId)
 );

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -95,23 +95,24 @@ export const HYDRA_PARA_ID = '';
 export const BASILISK_PARA_ID = '2090';
 
 export interface RouterConfigs {
-  [routerChainId: string]: {
-    [destChainName: string]: string[];
-  }
+  [destChainName: string]: string[];
 }
 
+export const ETH_USDC = '0x07865c6e87b9f70255377e024ace6630c1eaa37f';
+
 const ROUTE_SUPPORTED_CHAINS_AND_ASSETS_DEV: RouterConfigs = {
-  // [CHAIN_ID_ACALA]: {
   //   [HYDRA_PARA_ID]: [
-  //     '0x07865c6e87b9f70255377e024ace6630c1eaa37f',     // USDC
+  //     ETH_USDC,
   //   ],
-  // },
-  [CHAIN_ID_KARURA]: {
-    [BASILISK_PARA_ID]: [
-      '0x07865c6e87b9f70255377e024ace6630c1eaa37f',     // USDC
-    ],
-  },
+  [BASILISK_PARA_ID]: [
+    ETH_USDC,
+  ],
 };
+
+export const RouterChainIdByDestParaId = {
+  [BASILISK_PARA_ID]: CHAIN_ID_KARURA,
+  [HYDRA_PARA_ID]: CHAIN_ID_ACALA,
+} as const;
 
 const ROUTE_SUPPORTED_CHAINS_AND_ASSETS_PROD: RouterConfigs = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { relay, checkShouldRelay, getVersion } from './relay';
 import { TESTNET_MODE_WARNING, VERSION } from './consts';
 import { handleRelayAndRoute, handleRouteXcm, shouldRouteXcm } from './route';
 import { validateRelayAndRouteArgs, validateRouteXcmArgs, validateshouldRouteXcmArgs } from './middlewares/validate';
-import { Wallet } from 'ethers';
 
 dotenv.config({ path: '.env' });
 const PORT = process.env.PORT || 3111;

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -3,14 +3,12 @@ import { string, object, ObjectSchema } from 'yup';
 import { RelayAndRouteParams, RouteParamsXcm } from '../route';
 
 const routeParamsXcmSchema: ObjectSchema<RouteParamsXcm> = object({
-  routerChainId: string().required(),
   originAddr: string().required(),
   destParaId: string().required(),
   dest: string().required(),
 });
 
 const relayAndRouteParamsSchema: ObjectSchema<RelayAndRouteParams> = object({
-  routerChainId: string().required(),
   originAddr: string().required(),
   destParaId: string().required(),
   dest: string().required(),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,8 +113,8 @@ export const getSigner = async ({
   nodeUrl,
   walletPrivateKey,
 }: {
-  nodeUrl: string,
-  walletPrivateKey: string,
+  nodeUrl: string;
+  walletPrivateKey: string;
 }): Promise<Signer> => {
   const provider = EvmRpcProvider.from(nodeUrl);
   await provider.isReady();
@@ -141,8 +141,8 @@ export const bridgeToken = async (
   targetChain: ChainId,
   amount: BigNumberish,
 ): Promise<{
-  receipt: ContractReceipt,
-  sequence: string,
+  receipt: ContractReceipt;
+  sequence: string;
 }> => {
   const hexString = nativeToHexString(recipientAddr, targetChain);
   if (!hexString) {


### PR DESCRIPTION
## Change
- remove `routerChainId` params, instead it's now returned by `/shouldRouteXcm`
- `/relayAndRoute` nows returns both relay receipt and route receipt, in case we need them both

## Test
manually tested and all tests still pass