### PR TITLE
enabled test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -27,6 +29,7 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value={{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run Tests and Show Coverage Report
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: setup yarn
+        run: npm install -g yarn
+
+      - name: install deps
+        run: yarn install --immutable
+
+      - name: run tests
+        run: yarn test:coverage
+
+      - name: upload coverage reports
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install --immutable
 
       - name: setup test env
-        run: cp .env.example .env
+        run: cp .env.test .env
 
       - name: run tests
         run: yarn test:coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: install deps
         run: yarn install --immutable
 
+      - name: setup test env
+        run: cp .env.example .env
+
       - name: run tests
         run: yarn test:coverage
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@ The relayer to pay gas fee and redeem token on Karura/Acala after user send toke
 
 ## Run Locally
 - install deps: `yarn`
-- start: `yarn start`
-- start dev server: `yarn dev`
-- test: `yarn test`
+- build: `yarn build`
+- start with dist code: `yarn start`
+- start with dev server: `yarn dev`
 
 ## Run with Docker
 docker-compose version: `docker-compose version 1.29.2, build 5becea4c`
 
 - start dev server with docker: `docker-compose up`
-- start dev server with docker in background: `docker-compose up -d --build`
+- start dev server with docker in background: `docker compose up -d --build`
 
 ## Endpoints
 ### `/version`
 get the relayer version
 ```
 GET /version
-1.0.0
+1.3.10
 ```
 
 ### `/shouldRelay`
@@ -319,6 +319,18 @@ A complete working flow can be found in [routing e2e tests](./src/__tests__/rout
 4) fetch VAA and redeem on the target evm chain
 
 ## Tests
+### with coverage report
+- run tests and generate coverage data
+```
+yarn test:coverage
+```
+
+show coverage report in GUI
+```
+yarn vite preview --outDir ./coverage/
+```
+
+### with separate relayer (no coverage report)
 first start a relayer: `yarn dev`
 
 ```
@@ -330,4 +342,4 @@ yarn test:route
 ```
 
 ## Production Config
-modify `.env` to use real private keys for relayers, also set `TESTNET_MODE=0`
+`cp .env.example .env` and replace the test keys with real private keys for relayers

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:shouldRelay": "vitest src/__tests__/shouldRelay.test.ts",
     "test:shouldRoute": "vitest src/__tests__/shouldRoute.test.ts",
     "test:route": "vitest src/__tests__/route.test.ts",
-    "test:coverage": "COVERAGE=1 vitest src/__tests__/shouldRelay.test.ts src/__tests__/shouldRoute.test.ts",
+    "test:coverage": "COVERAGE=1 vitest src/__tests__/shouldRelay.test.ts src/__tests__/shouldRoute.test.ts --coverage",
     "relay": "ts-node src/scripts/manual-relay.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:shouldRelay": "vitest src/__tests__/shouldRelay.test.ts",
     "test:shouldRoute": "vitest src/__tests__/shouldRoute.test.ts",
     "test:route": "vitest src/__tests__/route.test.ts",
+    "test:coverage": "COVERAGE=1 vitest src/__tests__/shouldRelay.test.ts src/__tests__/shouldRoute.test.ts",
     "relay": "ts-node src/scripts/manual-relay.ts"
   },
   "dependencies": {
@@ -46,9 +47,11 @@
     "@types/long": "^4.0.1",
     "@types/node": "^16.6.1",
     "@types/react": "^17.0.19",
+    "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "@vitest/coverage-v8": "^0.33.0",
+    "@vitest/ui": "^0.33.0",
     "copy-dir": "^1.3.0",
     "eslint": "^8.9.0",
     "eslint-plugin-import": "^2.27.5",
@@ -56,6 +59,7 @@
     "nodemon": "^2.0.15",
     "pino-pretty": "^10.0.0",
     "prettier": "^2.3.2",
+    "supertest": "^6.3.3",
     "ts-node": "^10.5.0",
     "typescript": "^4.3.5",
     "vitest": "^0.33.0"

--- a/src/__tests__/shouldRelay.test.ts
+++ b/src/__tests__/shouldRelay.test.ts
@@ -1,37 +1,35 @@
 import { describe, it } from 'vitest';
 import { expect } from 'chai';
-import axios from 'axios';
 
-import { RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS, RELAYER_URL } from '../consts';
+import { RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS } from '../consts';
+import { shouldRelay } from './testUtils';
 
 describe('/shouldRelay', () => {
-  const checkShouldRelay = (params: any) => axios.get(RELAYER_URL.SHOULD_RELAY, { params });
-
   it('when should relay', async () => {
     for (const targetChain in RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS) {
       const supported = RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS[targetChain];
 
       for (const [token, minTransfer] of Object.entries(supported)) {
-        const res = await checkShouldRelay({
+        const res = await shouldRelay({
           targetChain,
           originAsset: token,
           amount: minTransfer,
         });
 
-        expect(res.data.shouldRelay).to.equal(true);
-        expect(res.data.msg).to.equal('');
+        expect(res.shouldRelay).to.equal(true);
+        expect(res.msg).to.equal('');
       }
 
       // if not lower case address
       for (const [token, minTransfer] of Object.entries(supported)) {
-        const res = await checkShouldRelay({
+        const res = await shouldRelay({
           targetChain,
           originAsset: token.toUpperCase(),
           amount: minTransfer,
         });
 
-        expect(res.data.shouldRelay).to.equal(true);
-        expect(res.data.msg).to.equal('');
+        expect(res.shouldRelay).to.equal(true);
+        expect(res.msg).to.equal('');
       }
     }
   });
@@ -40,64 +38,64 @@ describe('/shouldRelay', () => {
     const USDT_BSC = '0x337610d27c682e347c9cd60bd4b3b107c9d34ddd';
 
     it('when missing params', async () => {
-      let res = await checkShouldRelay({
+      let res = await shouldRelay({
         originAsset: '0xddb64fe46a91d46ee29420539fc25fd07c5fea3e',
         amount: '10000',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal('missing targetChain');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal('missing targetChain');
 
-      res = await checkShouldRelay({
+      res = await shouldRelay({
         targetChain: 11,
         amount: '10000',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal('missing originAsset');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal('missing originAsset');
 
-      res = await checkShouldRelay({
+      res = await shouldRelay({
         targetChain: 11,
         originAsset: '0xddb64fe46a91d46ee29420539fc25fd07c5fea3e',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal('missing transfer amount');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal('missing transfer amount');
     });
 
     it('when relay condition not met', async () => {
-      let res = await checkShouldRelay({
+      let res = await shouldRelay({
         targetChain: 12345,
         originAsset: '0xddb64fe46a91d46ee29420539fc25fd07c5fea3e',
         amount: '10000',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal('target chain not supported');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal('target chain not supported');
 
-      res = await checkShouldRelay({
+      res = await shouldRelay({
         targetChain: 11,
         originAsset: '0x111111111191d46ee29420539fc25f0000000000',
         amount: '10000',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal('token not supported');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal('token not supported');
 
       const targetChain = 11;
       const originAsset = USDT_BSC;
-      res = await checkShouldRelay({
+      res = await shouldRelay({
         targetChain,
         originAsset,
         amount: '10000',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.equal(`transfer amount too small, expect at least ${RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS[targetChain][originAsset]}`);
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.equal(`transfer amount too small, expect at least ${RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS[targetChain][originAsset]}`);
     });
 
     it('when amount is not number', async () => {
-      const res = await checkShouldRelay({
+      const res = await shouldRelay({
         targetChain: 11,
         originAsset: USDT_BSC,
         amount: '{"type":"BigNumber","hex":"0xe8d4a51000"}',
       });
-      expect(res.data.shouldRelay).to.equal(false);
-      expect(res.data.msg).to.contain('failed to parse amount');
+      expect(res.shouldRelay).to.equal(false);
+      expect(res.msg).to.contain('failed to parse amount');
     });
   });
 });

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -1,9 +1,13 @@
 import { CHAIN_ID_KARURA } from '@certusone/wormhole-sdk';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from 'ethers';
+import axios from 'axios';
+import request from 'supertest';
 
-import { ETH_RPC } from '../consts';
+import { ETH_RPC, RELAYER_API, RELAYER_URL } from '../consts';
 import { TEST_USER_PRIVATE_KEY } from './testConsts';
+import { createApp } from '../app';
+import { expect } from 'vitest';
 import { transferFromBSC } from '../utils/utils';
 
 export const transferFromBSCToKaruraTestnet = async (
@@ -22,4 +26,56 @@ export const transferFromBSCToKaruraTestnet = async (
     wallet,
     false,
   );
+};
+
+const app = createApp();
+export const appReq = request(app);
+
+export const shouldRouteXcm = process.env.COVERAGE
+  ? async (params: any) => {
+    const res = await appReq.get(RELAYER_API.SHOULD_ROUTE_XCM).query(params);
+    if (res.error) {
+      throw res.error;
+    };
+    return JSON.parse(res.text);
+  }
+  : async (params: any) => {
+    const res = await axios.get(RELAYER_URL.SHOULD_ROUTE_XCM, { params });
+    return res.data;
+  };
+
+export const shouldRouteWormhole = process.env.COVERAGE
+  ? async (params: any) => {
+    const res = await appReq.get(RELAYER_API.SHOULD_ROUTE_WORMHOLE).query(params);
+    if (res.error) {
+      throw res.error;
+    };
+    return JSON.parse(res.text);
+  }
+  : async (params: any) => {
+    const res = await axios.get(RELAYER_URL.SHOULD_ROUTE_WORMHOLE, { params });
+    return res.data;
+  };
+
+export const shouldRelay = process.env.COVERAGE
+  ? async (params: any) => {
+    const res = await appReq.get(RELAYER_API.SHOULD_RELAY).query(params);
+    if (res.error) {
+      throw res.error;
+    };
+    return JSON.parse(res.text);
+  }
+  : async (params: any) => {
+    const res = await axios.get(RELAYER_URL.SHOULD_RELAY, { params });
+    return res.data;
+  };
+
+export const expectError = (err: any, msg: any, code: number) => {
+  if (axios.isAxiosError(err)) {
+    expect(err.response?.status).to.equal(code);
+    expect(err.response?.data.error).to.deep.equal(msg);
+  } else {    // HttpError from supertest
+    expect(err.status).to.equal(code);
+    expect(JSON.parse(err.text).error).to.deep.equal(msg);
+  }
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,26 @@
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import express from 'express';
+
+import { checkShouldRelay, getVersion, relay } from './api/relay';
+import { errorHandler } from './middlewares/error';
+import { testTimeout } from './utils/utils';
+import router from './middlewares/router';
+
+export const createApp = () => {
+  const app = express();
+
+  app.use(cors());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(bodyParser.json());
+
+  app.post('/relay', relay);
+  app.post('/testTimeout', testTimeout);
+  app.get('/shouldRelay', checkShouldRelay);
+  app.get('/version', getVersion);
+
+  app.use(router);
+  app.use(errorHandler);
+
+  return app;
+};

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -32,16 +32,29 @@ export const WORMHOLE_GUARDIAN_RPC = {
 const RELAYER_BASE_URL = 'http://localhost:3111';
 // const RELAYER_BASE_URL = 'https://relayer.aca-dev.network';
 // const RELAYER_BASE_URL = 'https://relayer.aca-api.network';
+
+export const RELAYER_API = {
+  SHOULD_RELAY: '/shouldRelay',
+  RELAY: '/relay',
+
+  SHOULD_ROUTE_XCM: '/shouldRouteXcm',
+  ROUTE_XCM: '/routeXcm',
+
+  SHOULD_ROUTE_WORMHOLE: '/shouldRouteWormhole',
+  ROUTE_WORMHOLE: '/routeWormhole',
+  RELAY_AND_ROUTE: '/relayAndRoute',
+} as const;
+
 export const RELAYER_URL = {
-  SHOULD_RELAY: `${RELAYER_BASE_URL}/shouldRelay`,
-  RELAY: `${RELAYER_BASE_URL}/relay`,
+  SHOULD_RELAY: `${RELAYER_BASE_URL}${RELAYER_API.SHOULD_RELAY}`,
+  RELAY: `${RELAYER_BASE_URL}${RELAYER_API.RELAY}`,
 
-  SHOULD_ROUTE_XCM: `${RELAYER_BASE_URL}/shouldRouteXcm`,
-  ROUTE_XCM: `${RELAYER_BASE_URL}/routeXcm`,
+  SHOULD_ROUTE_XCM: `${RELAYER_BASE_URL}${RELAYER_API.SHOULD_ROUTE_XCM}`,
+  ROUTE_XCM: `${RELAYER_BASE_URL}${RELAYER_API.ROUTE_XCM}`,
 
-  SHOULD_ROUTE_WORMHOLE: `${RELAYER_BASE_URL}/shouldRouteWormhole`,
-  ROUTE_WORMHOLE: `${RELAYER_BASE_URL}/routeWormhole`,
-  RELAY_AND_ROUTE: `${RELAYER_BASE_URL}/relayAndRoute`,
+  SHOULD_ROUTE_WORMHOLE: `${RELAYER_BASE_URL}${RELAYER_API.SHOULD_ROUTE_WORMHOLE}`,
+  ROUTE_WORMHOLE: `${RELAYER_BASE_URL}${RELAYER_API.ROUTE_WORMHOLE}`,
+  RELAY_AND_ROUTE: `${RELAYER_BASE_URL}${RELAYER_API.RELAY_AND_ROUTE}`,
 } as const;
 
 /* ---------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,13 @@
-import bodyParser from 'body-parser';
-import cors from 'cors';
 import dotenv from 'dotenv';
-import express from 'express';
 
 import { TESTNET_MODE_WARNING, VERSION } from './consts';
-import { checkShouldRelay, getVersion, relay } from './api/relay';
-import { errorHandler } from './middlewares/error';
-import { testTimeout } from './utils/utils';
-import router from './middlewares/router';
+import { createApp } from './app';
 
 dotenv.config({ path: '.env' });
 const PORT = process.env.PORT || 3111;
 
 const startServer = async (): Promise<void> => {
-  const app = express();
-
-  app.use(cors());
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(bodyParser.json());
-
-  app.post('/relay', relay);
-  app.post('/testTimeout', testTimeout);
-  app.get('/shouldRelay', checkShouldRelay);
-  app.get('/version', getVersion);
-
-  app.use(router);
-  app.use(errorHandler);
+  const app = createApp();
 
   app.listen(PORT, () => {
     console.log(`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
-      enabled: true,
+      enabled: false,
       exclude: ['**/__tests__'],
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,9 +9,9 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      all: true,
       reportsDirectory: './coverage',
-      enabled: false,
+      enabled: true,
+      exclude: ['**/__tests__'],
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,11 @@
   dependencies:
     "@open-web3/orml-type-definitions" "2.0.1"
 
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+
 "@polkadot/api-augment@10.6.1":
   version "10.6.1"
   resolved "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.6.1.tgz#95f99070ae61ff3d3dbdd1be9cecf68a6b3174c7"
@@ -1857,6 +1862,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.34"
   resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.34.tgz#c119e85b75215178bc127de588e93100698ab4cc"
@@ -2008,6 +2018,21 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/superagent@*":
+  version "4.1.18"
+  resolved "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.18.tgz#e8f037d015cb3b55e64dd00c4d07a84be6d16d34"
+  integrity sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/supertest@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz#ddb4a0568597c9aadff8dbec5b2e8fddbe8692fc"
+  integrity sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==
+  dependencies:
+    "@types/superagent" "*"
+
 "@types/ws@^7.4.4":
   version "7.4.7"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
@@ -2149,6 +2174,19 @@
   integrity sha512-Kv+yZ4hnH1WdiAkPUQTpRxW8kGtH8VRTnus7ZTGovFYM1ZezJpvGtb9nPIjPnptHbsyIAxYZsEpVPYgtpjGnrg==
   dependencies:
     tinyspy "^2.1.1"
+
+"@vitest/ui@^0.33.0":
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/@vitest/ui/-/ui-0.33.0.tgz#6ee8f1149d5398f929c5dd2697fd2096ecfe9c47"
+  integrity sha512-7gbAjLqt30R4bodkJAutdpy4ncv+u5IKTHYTow1c2q+FOxZUC9cKOSqMUxjwaaTwLN+EnDnmXYPtg3CoahaUzQ==
+  dependencies:
+    "@vitest/utils" "0.33.0"
+    fast-glob "^3.3.0"
+    fflate "^0.8.0"
+    flatted "^3.2.7"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    sirv "^2.0.3"
 
 "@vitest/utils@0.33.0":
   version "0.33.0"
@@ -2405,6 +2443,11 @@ array.prototype.flatmap@^1.3.1:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
+
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 assertion-error@^1.1.0:
   version "1.1.0"
@@ -2823,6 +2866,11 @@ commander@^2.20.3:
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+component-emitter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2854,6 +2902,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 copy-dir@^1.3.0:
   version "1.3.0"
@@ -3054,6 +3107,14 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 diff-sequences@^29.4.3:
   version "29.4.3"
@@ -3699,6 +3760,17 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
+  integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -3738,6 +3810,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   dependencies:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
+
+fflate@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz#f93ad1dcbe695a25ae378cf2386624969a7cda32"
+  integrity sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -3787,7 +3864,7 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flatted@^3.1.0:
+flatted@^3.1.0, flatted@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
@@ -3828,6 +3905,16 @@ formdata-polyfill@^4.0.10:
   integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
   dependencies:
     fetch-blob "^3.1.2"
+
+formidable@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
+  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
+    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4082,6 +4169,11 @@ help-me@^4.0.1:
   dependencies:
     glob "^8.0.0"
     readable-stream "^3.6.0"
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 hi-base32@^0.5.1:
   version "0.5.1"
@@ -4719,7 +4811,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -4748,6 +4840,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -4797,6 +4894,11 @@ mock-socket@^9.2.1:
   version "9.2.1"
   resolved "https://registry.npmjs.org/mock-socket/-/mock-socket-9.2.1.tgz#cc9c0810aa4d0afe02d721dcb2b7e657c00e2282"
   integrity sha512-aw9F9T9G2zpGipLLhSNh6ZpgUyUl4frcVmRN08uE1NWPWg43Wx6+sGPDbQ7E5iFZZDJW5b5bypMeAEHqTbIFag==
+
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -5337,6 +5439,13 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.11.0:
+  version "6.11.2"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -5637,6 +5746,13 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -5745,6 +5861,15 @@ simple-update-notifier@^1.0.7:
   integrity sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==
   dependencies:
     semver "~7.0.0"
+
+sirv@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz#ca5868b87205a74bef62a469ed0296abceccd446"
+  integrity sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^3.0.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5909,6 +6034,22 @@ strip-literal@^1.0.1:
   dependencies:
     acorn "^8.8.2"
 
+superagent@^8.0.5:
+  version "8.0.9"
+  resolved "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz#2c6fda6fadb40516515f93e9098c0eb1602e0535"
+  integrity sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.1.2"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
+
 superstruct@^0.14.2:
   version "0.14.2"
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
@@ -5923,6 +6064,14 @@ superstruct@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz#de626a5b49c6641ff4d37da3c7598e7a87697046"
   integrity sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==
+
+supertest@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
+  integrity sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.0.5"
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
@@ -6059,6 +6208,11 @@ toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
   integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
+
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
 touch@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Context
Previously when testing, we usually first start server, then run tests on another terminal. However, in order to enable test coverage, we have to run tests and the server in the same process, i.e. starting server by test file directly, then run the tests. 

## Change
modified app and tests to support testing in both way:
- when running tests by `COVERAGE=1 yarn vitest ... --coverage`, it will start the server and tests together. This is used by CI mostly, to show coverage report **AFTER** all tests passed
- when running tests normally without `COVERAGE=1`, we first start a server separately as usual. This is more convenient in the development phase, since the `{test, server}` logging is separated and much easier to debug. Also this can avoid starting server over and over again every time we run the tests.

## Test
- testing in both way still works
- can show codecov report on the PR

## Todo
now the scope is limited to `/should*` endpoints. For other endpoints that are more e2e, we rely on BSC testnet which is super unstable to integrate with CI. Maybe we can try AVAX testnet instead