### PR TITLE
add `/health` endpoint

### DIFF
--- a/src/__tests__/misc.test.ts
+++ b/src/__tests__/misc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { expectError, noRoute, testTimeout, version } from './testUtils';
+import { expectError, health, noRoute, testTimeout, version } from './testUtils';
 
 describe.concurrent('/miscellaneous', () => {
   describe('when no route for the request', () => {
@@ -30,6 +30,16 @@ describe.concurrent('/miscellaneous', () => {
       const endTime = Date.now();
 
       expect(endTime - startTime).to.be.gte(1000);
+    });
+  });
+
+  describe('/health', () => {
+    it('works', async () => {
+      const res = await health({});
+
+      expect(Number(res.data.relayerBalAcala)).to.be.gt(0);
+      expect(Number(res.data.relayerBalKarura)).to.be.gt(0);
+      expect(res.data.isHealthy).to.be.true;
     });
   });
 });

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -169,6 +169,10 @@ export const testTimeout = process.env.COVERAGE
   ? _supertestPost(RELAYER_API.TEST_TIMEOUT)
   : _axiosPost(RELAYER_URL.TEST_TIMEOUT);
 
+export const health = process.env.COVERAGE
+  ? _supertestGet(RELAYER_API.HEALTH)
+  : _axiosGet(RELAYER_URL.HEALTH);
+
 export const shouldRouteHoma = process.env.COVERAGE
   ? _supertestGet(RELAYER_API.GET_HOMA_ROUTER_ADDR)
   : _axiosGet(RELAYER_URL.GET_HOMA_ROUTER_ADDR);

--- a/src/api/health.ts
+++ b/src/api/health.ts
@@ -1,0 +1,30 @@
+import { CHAIN_ID_ACALA, CHAIN_ID_KARURA } from '@certusone/wormhole-sdk';
+import { formatEther, parseEther } from 'ethers/lib/utils';
+
+import { getChainConfig } from '../utils';
+
+const MIN_BALANCE_ACALA = parseEther('15');
+const MIN_BALANCE_KARURA = parseEther('10');
+
+export const healthCheck = async () => {
+  const [chainConfigAcala, chainConfigKarura] = await Promise.all([
+    getChainConfig(CHAIN_ID_ACALA),
+    getChainConfig(CHAIN_ID_KARURA),
+  ]);
+
+  const [relayerBalAcala, relayerBalKarura] = await Promise.all([
+    chainConfigAcala.wallet.getBalance(),
+    chainConfigKarura.wallet.getBalance(),
+  ]);
+
+  const isHealthy = (
+    relayerBalAcala.gt(MIN_BALANCE_ACALA) &&
+    relayerBalKarura.gt(MIN_BALANCE_KARURA)
+  );
+
+  return {
+    relayerBalAcala: formatEther(relayerBalAcala),
+    relayerBalKarura: formatEther(relayerBalKarura),
+    isHealthy,
+  };
+};

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -59,6 +59,7 @@ export const RELAYER_API = {
   NO_ROUTE: '/noRoute',
   VERSION: '/version',
   TEST_TIMEOUT: '/testTimeout',
+  HEALTH: '/health',
 } as const;
 
 export const RELAYER_URL = {
@@ -79,6 +80,7 @@ export const RELAYER_URL = {
   NO_ROUTE: `${RELAYER_BASE_URL}${RELAYER_API.NO_ROUTE}`,
   VERSION: `${RELAYER_BASE_URL}${RELAYER_API.VERSION}`,
   TEST_TIMEOUT: `${RELAYER_BASE_URL}${RELAYER_API.TEST_TIMEOUT}`,
+  HEALTH: `${RELAYER_BASE_URL}${RELAYER_API.HEALTH}`,
 } as const;
 
 /* ---------------

--- a/src/middlewares/router.ts
+++ b/src/middlewares/router.ts
@@ -2,17 +2,18 @@ import { NextFunction, Request, Response } from 'express';
 import { Schema } from 'yup';
 
 import { NoRouteError } from './error';
+import { healthCheck } from '../api/health';
+import { logger } from '../utils';
 import {
-  shouldRouteHoma,
   relayAndRoute,
   relayAndRouteBatch,
   routeHoma,
   routeWormhole,
   routeXcm,
+  shouldRouteHoma,
   shouldRouteWormhole,
   shouldRouteXcm,
 } from '../api/route';
-import { logger } from '../utils';
 import {
   relayAndRouteSchema,
   routeHomaSchema,
@@ -21,7 +22,7 @@ import {
 } from '../utils/validate';
 
 interface RouterConfig {
-  schema: Schema;
+  schema?: Schema;
   handler: (data: any) => Promise<any>;
 }
 
@@ -42,6 +43,10 @@ const ROUTER_CONFIGS: {
     '/shouldRouteHoma': {
       schema: routeHomaSchema,
       handler: shouldRouteHoma,
+    },
+    '/health': {
+      schema: undefined,
+      handler: healthCheck,
     },
   },
 
@@ -83,7 +88,7 @@ const handleRoute = async (req: Request, res: Response) => {
     throw new NoRouteError(`${reqPath} not supported`);
   }
 
-  await config.schema.validate(args, { abortEarly: false });
+  await config.schema?.validate(args, { abortEarly: false });
   const data = await config.handler(args);
 
   logger.info({ data }, `✨ ${reqPath}`);

--- a/src/middlewares/router.ts
+++ b/src/middlewares/router.ts
@@ -45,7 +45,6 @@ const ROUTER_CONFIGS: {
       handler: shouldRouteHoma,
     },
     '/health': {
-      schema: undefined,
       handler: healthCheck,
     },
   },


### PR DESCRIPTION
## Change
Added `/health` endpoint that checks relayer balance for both karura and acala, this will be helpful for datadog monitoring.

## Test
added test for it and works as expected