### PR TITLE
auto route polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,12 +431,20 @@ data: {
 
 GET /routeStatus?routeId=homa-1711514333845
 => route status
-{ data: { status: 0 } }                     // waiting for token
-{ data: { status: 1 } }                     // token arrived, routing
-{ data: { status: 2, txHash: '0x12345 } }   // routing tx submitted, waiting for confirmation
-{ data: { status: 3, txHash: '0x12345 } }   // routing completed
-{ data: { status: -1 } }                    // routing timeout out (usually becuase no token arrive in 3 min)
-{ data: { status: -2, error: 'xxx' } }      // routing failed
+[{ data: { status: 0 } }]                     // waiting for token
+[{ data: { status: 1 } }]                     // token arrived, routing
+[{ data: { status: 2, txHash: '0x12345' } }]   // routing tx submitted, waiting for confirmation
+[{ data: { status: 3, txHash: '0x12345' } }]   // routing completed
+[{ data: { status: -1 } }]                    // routing timeout out (usually becuase no token arrive in 3 min)
+[{ data: { status: -2, error: 'xxx' } }]      // routing failed
+
+GET /routeStatus?destAddr=0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6
+=> all route status for this address
+[
+  { data: { status: 3, txHash: '0x11111' } },
+  { data: { status: 2, txHash: '0x22222' } },
+  { data: { status: 1 } },
+]
 ```
 
 /* ---------- when error ---------- */

--- a/src/__tests__/route.test.ts
+++ b/src/__tests__/route.test.ts
@@ -1,19 +1,10 @@
-import { ADDRESSES } from '@acala-network/asset-router/dist/consts';
 import { AcalaJsonRpcProvider, sleep } from '@acala-network/eth-providers';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { CHAIN_ID_AVAX, CHAIN_ID_KARURA, CONTRACTS, hexToUint8Array, parseSequenceFromLogEth, redeemOnEth } from '@certusone/wormhole-sdk';
 import { ContractReceipt, Wallet } from 'ethers';
-import { DOT, LDOT } from '@acala-network/contracts/utils/AcalaTokens';
 import { ERC20__factory } from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
-import { EVMAccounts__factory, IHoma__factory } from '@acala-network/contracts/typechain';
-import { EVM_ACCOUNTS, HOMA } from '@acala-network/contracts/utils/Predeploy';
-import { FeeRegistry__factory } from '@acala-network/asset-router/dist/typechain-types';
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { ONE_ACA, almostEq, toHuman } from '@acala-network/asset-router/dist/utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { encodeAddress } from '@polkadot/util-crypto';
-import { parseEther, parseUnits } from 'ethers/lib/utils';
-import assert from 'assert';
 
 import {
   BASILISK_TESTNET_NODE_URL,
@@ -23,7 +14,6 @@ import {
   TEST_KEY,
 } from './testConsts';
 import { ETH_RPC, FUJI_TOKEN, GOERLI_USDC, PARA_ID } from '../consts';
-import { RouteStatus } from '../api';
 import {
   encodeXcmDest,
   expectError,
@@ -32,12 +22,8 @@ import {
   mockXcmToRouter,
   relayAndRoute,
   relayAndRouteBatch,
-  routeHoma,
-  routeHomaAuto,
-  routeStatus,
   routeWormhole,
   routeXcm,
-  shouldRouteHoma,
   shouldRouteWormhole,
   shouldRouteXcm,
   transferFromFujiToKaruraTestnet,
@@ -59,10 +45,6 @@ const dest = encodeXcmDest({
 
 const providerKarura = new AcalaJsonRpcProvider(ETH_RPC.KARURA_TESTNET);
 const relayerKarura = new Wallet(TEST_KEY.RELAYER, providerKarura);
-
-const providerAcalaFork = new AcalaJsonRpcProvider(ETH_RPC.LOCAL);
-const relayerAcalaFork = new Wallet(TEST_KEY.RELAYER, providerAcalaFork);
-const userAcalaFork = new Wallet(TEST_KEY.USER, providerAcalaFork);
 
 describe('/routeXcm', () => {
   const api = new ApiPromise({ provider: new WsProvider(BASILISK_TESTNET_NODE_URL) });
@@ -374,209 +356,3 @@ describe('/routeWormhole', () => {
 
   // describe.skip('when should not route', () => {})
 });
-
-describe.skip('/routeHoma', () => {
-  const DOT_DECIMALS = 10;
-  const dot = ERC20__factory.connect(DOT, providerAcalaFork);
-  const ldot = ERC20__factory.connect(LDOT, providerAcalaFork);
-  const homa = IHoma__factory.connect(HOMA, providerAcalaFork);
-  const evmAccounts = EVMAccounts__factory.connect(EVM_ACCOUNTS, providerAcalaFork);
-  const fee = FeeRegistry__factory.connect(ADDRESSES.ACALA.feeAddr, providerAcalaFork);
-  const stakeAmount = 6;
-  const parsedStakeAmount = parseUnits(String(stakeAmount), DOT_DECIMALS);
-  let routerAddr: string;
-
-  const fetchTokenBalances = async () => {
-    if (!routerAddr) throw new Error('routerAddr not set');
-
-    const [
-      userBalDot,
-      relayerBalDot,
-      routerBalDot,
-      userBalLdot,
-      relayerBalLdot,
-      routerBalLdot,
-    ] = await Promise.all([
-      dot.balanceOf(TEST_ADDR_USER),
-      dot.balanceOf(TEST_ADDR_RELAYER),
-      dot.balanceOf(routerAddr),
-      ldot.balanceOf(TEST_ADDR_USER),
-      ldot.balanceOf(TEST_ADDR_RELAYER),
-      ldot.balanceOf(routerAddr),
-    ]);
-
-    console.log({
-      userBalDot: toHuman(userBalDot, DOT_DECIMALS),
-      relayerBalDot: toHuman(relayerBalDot, DOT_DECIMALS),
-      routerBalDot: toHuman(routerBalDot, DOT_DECIMALS),
-      userBalLdot: toHuman(userBalLdot, DOT_DECIMALS),
-      relayerBalLdot: toHuman(relayerBalLdot, DOT_DECIMALS),
-      routerBalLdot: toHuman(routerBalLdot, DOT_DECIMALS),
-    });
-
-    return {
-      userBalDot,
-      relayerBalDot,
-      routerBalDot,
-      userBalLdot,
-      relayerBalLdot,
-      routerBalLdot,
-    };
-  };
-
-  const testHomaRouter = async (destAddr: string) => {
-    const relayerBal = await relayerAcalaFork.getBalance();
-    assert(relayerBal.gt(parseEther('10')), `relayer doesn't have enough balance to relay! ${relayerAcalaFork.address}`);
-
-    const routeArgs = {
-      destAddr,
-      chain: 'acala',
-    };
-    const res = await shouldRouteHoma(routeArgs);
-    ({ routerAddr } = res.data);
-
-    // make sure user has enough DOT to transfer to router
-    const bal = await fetchTokenBalances();
-    if (bal.userBalDot.lt(parsedStakeAmount)) {
-      if (bal.relayerBalDot.lt(parsedStakeAmount)) {
-        throw new Error('both relayer and user do not have enough DOT to transfer to router!');
-      }
-
-      console.log('refilling dot for user ...');
-      await (await dot.connect(relayerAcalaFork).transfer(TEST_ADDR_USER, parsedStakeAmount)).wait();
-    }
-
-    const bal0 = await fetchTokenBalances();
-
-    console.log('xcming to router ...');
-    await mockXcmToRouter(routerAddr, userAcalaFork, DOT, stakeAmount);
-
-    console.log('routing ...');
-    const routeRes = await routeHoma({
-      ...routeArgs,
-      token: DOT,
-    });
-    const txHash = routeRes.data;
-    console.log(`route finished! txHash: ${txHash}`);
-
-    const bal1 = await fetchTokenBalances();
-
-    // router should be destroyed
-    const routerCode = await providerKarura.getCode(routerAddr);
-    expect(routerCode).to.eq('0x');
-    expect(bal1.routerBalDot.toNumber()).to.eq(0);
-    expect(bal1.routerBalLdot.toNumber()).to.eq(0);
-
-    // user should receive LDOT
-    const routingFee = await fee.getFee(DOT);
-    const exchangeRate = await homa.getExchangeRate();   // 10{18} LDOT => ? DOT
-    const expectedLdot = parsedStakeAmount.sub(routingFee).mul(ONE_ACA).div(exchangeRate);
-    const ldotReceived = bal1.userBalLdot.sub(bal0.userBalLdot);
-
-    expect(almostEq(expectedLdot, ldotReceived)).to.be.true;
-    expect(bal0.userBalDot.sub(bal1.userBalDot).toBigInt()).to.eq(parsedStakeAmount.toBigInt());
-
-    // relayer should receive DOT fee
-    expect(bal1.relayerBalDot.sub(bal0.relayerBalDot).toBigInt()).to.eq(routingFee.toBigInt());
-  };
-
-  const testAutoHomaRouter = async (destAddr: string) => {
-    const relayerBal = await relayerAcalaFork.getBalance();
-    assert(relayerBal.gt(parseEther('10')), `relayer doesn't have enough balance to relay! ${relayerAcalaFork.address}`);
-
-    const routeArgs = {
-      destAddr,
-      chain: 'acala',
-    };
-    const res = await shouldRouteHoma(routeArgs);
-    ({ routerAddr } = res.data);
-
-    // make sure user has enough DOT to transfer to router
-    const bal = await fetchTokenBalances();
-    if (bal.userBalDot.lt(parsedStakeAmount)) {
-      if (bal.relayerBalDot.lt(parsedStakeAmount)) {
-        throw new Error('both relayer and user do not have enough DOT to transfer to router!');
-      }
-
-      console.log('refilling dot for user ...');
-      await (await dot.connect(relayerAcalaFork).transfer(TEST_ADDR_USER, parsedStakeAmount)).wait();
-    }
-
-    const bal0 = await fetchTokenBalances();
-
-    console.log('sending auto routing request ...');
-    const routeRes = await routeHomaAuto({
-      ...routeArgs,
-      token: DOT,
-    });
-    const reqId = routeRes.data;
-    console.log(`auto route submitted! reqId: ${reqId}`);
-
-    const waitForRoute = new Promise<void>((resolve, reject) => {
-      const pollRouteStatus = setInterval(async () => {
-        const res = await routeStatus({ id: reqId });
-        // console.log(`current status: ${res.data.status}`);
-
-        if (res.data.status === RouteStatus.Complete) {
-          resolve();
-          clearInterval(pollRouteStatus);
-        }
-      }, 1000);
-
-      setTimeout(reject, 100 * 1000);
-    });
-
-    console.log('xcming to router ...');
-    await mockXcmToRouter(routerAddr, userAcalaFork, DOT, stakeAmount);
-
-    console.log('waiting for auto routing ...');
-    await waitForRoute;
-
-    console.log('route complete!');
-    const bal1 = await fetchTokenBalances();
-
-    // router should be destroyed
-    const routerCode = await providerKarura.getCode(routerAddr);
-    expect(routerCode).to.eq('0x');
-    expect(bal1.routerBalDot.toNumber()).to.eq(0);
-    expect(bal1.routerBalLdot.toNumber()).to.eq(0);
-
-    // user should receive LDOT
-    const routingFee = await fee.getFee(DOT);
-    const exchangeRate = await homa.getExchangeRate();   // 10{18} LDOT => ? DOT
-    const expectedLdot = parsedStakeAmount.sub(routingFee).mul(ONE_ACA).div(exchangeRate);
-    const ldotReceived = bal1.userBalLdot.sub(bal0.userBalLdot);
-
-    expect(almostEq(expectedLdot, ldotReceived)).to.be.true;
-    expect(bal0.userBalDot.sub(bal1.userBalDot).toBigInt()).to.eq(parsedStakeAmount.toBigInt());
-
-    // relayer should receive DOT fee
-    expect(bal1.relayerBalDot.sub(bal0.relayerBalDot).toBigInt()).to.eq(routingFee.toBigInt());
-  };
-
-  it('route to evm address', async () => {
-    await testHomaRouter(TEST_ADDR_USER);
-  });
-
-  it('route to substrate address', async () => {
-    const ACALA_SS58_PREFIX = 10;
-    const userAccountId = await evmAccounts.getAccountId(TEST_ADDR_USER);
-    const userSubstrateAddr = encodeAddress(userAccountId, ACALA_SS58_PREFIX);
-
-    await testHomaRouter(userSubstrateAddr);
-  });
-
-  it('auto route to evm address', async () => {
-    await testAutoHomaRouter(TEST_ADDR_USER);
-  });
-
-  it('auto route to substrate address', async () => {
-    const ACALA_SS58_PREFIX = 10;
-    const userAccountId = await evmAccounts.getAccountId(TEST_ADDR_USER);
-    const userSubstrateAddr = encodeAddress(userAccountId, ACALA_SS58_PREFIX);
-
-    await testAutoHomaRouter(userSubstrateAddr);
-  });
-});
-
-

--- a/src/__tests__/routeHoma.test.ts
+++ b/src/__tests__/routeHoma.test.ts
@@ -1,0 +1,236 @@
+import { ADDRESSES } from '@acala-network/asset-router/dist/consts';
+import { AcalaJsonRpcProvider } from '@acala-network/eth-providers';
+import { DOT, LDOT } from '@acala-network/contracts/utils/AcalaTokens';
+import { ERC20__factory } from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
+import { EVMAccounts__factory, IHoma__factory } from '@acala-network/contracts/typechain';
+import { EVM_ACCOUNTS, HOMA } from '@acala-network/contracts/utils/Predeploy';
+import { FeeRegistry__factory } from '@acala-network/asset-router/dist/typechain-types';
+import { ONE_ACA, almostEq, toHuman } from '@acala-network/asset-router/dist/utils';
+import { Wallet } from 'ethers';
+import { describe, expect, it } from 'vitest';
+import { encodeAddress } from '@polkadot/util-crypto';
+import { parseEther, parseUnits } from 'ethers/lib/utils';
+import assert from 'assert';
+
+import { ETH_RPC } from '../consts';
+import { RouteStatus } from '../api';
+import {
+  TEST_ADDR_RELAYER,
+  TEST_ADDR_USER,
+  TEST_KEY,
+} from './testConsts';
+import {
+  mockXcmToRouter,
+  routeHoma,
+  routeHomaAuto,
+  routeStatus,
+  shouldRouteHoma,
+} from './testUtils';
+
+const providerAcalaFork = new AcalaJsonRpcProvider(ETH_RPC.LOCAL);
+const relayerAcalaFork = new Wallet(TEST_KEY.RELAYER, providerAcalaFork);
+const userAcalaFork = new Wallet(TEST_KEY.USER, providerAcalaFork);
+
+describe.only('/routeHoma', () => {
+  const DOT_DECIMALS = 10;
+  const dot = ERC20__factory.connect(DOT, providerAcalaFork);
+  const ldot = ERC20__factory.connect(LDOT, providerAcalaFork);
+  const homa = IHoma__factory.connect(HOMA, providerAcalaFork);
+  const evmAccounts = EVMAccounts__factory.connect(EVM_ACCOUNTS, providerAcalaFork);
+  const fee = FeeRegistry__factory.connect(ADDRESSES.ACALA.feeAddr, providerAcalaFork);
+  const stakeAmount = 6;
+  const parsedStakeAmount = parseUnits(String(stakeAmount), DOT_DECIMALS);
+  let routerAddr: string;
+
+  const fetchTokenBalances = async () => {
+    if (!routerAddr) throw new Error('routerAddr not set');
+
+    const [
+      userBalDot,
+      relayerBalDot,
+      routerBalDot,
+      userBalLdot,
+      relayerBalLdot,
+      routerBalLdot,
+    ] = await Promise.all([
+      dot.balanceOf(TEST_ADDR_USER),
+      dot.balanceOf(TEST_ADDR_RELAYER),
+      dot.balanceOf(routerAddr),
+      ldot.balanceOf(TEST_ADDR_USER),
+      ldot.balanceOf(TEST_ADDR_RELAYER),
+      ldot.balanceOf(routerAddr),
+    ]);
+
+    console.log({
+      userBalDot: toHuman(userBalDot, DOT_DECIMALS),
+      relayerBalDot: toHuman(relayerBalDot, DOT_DECIMALS),
+      routerBalDot: toHuman(routerBalDot, DOT_DECIMALS),
+      userBalLdot: toHuman(userBalLdot, DOT_DECIMALS),
+      relayerBalLdot: toHuman(relayerBalLdot, DOT_DECIMALS),
+      routerBalLdot: toHuman(routerBalLdot, DOT_DECIMALS),
+    });
+
+    return {
+      userBalDot,
+      relayerBalDot,
+      routerBalDot,
+      userBalLdot,
+      relayerBalLdot,
+      routerBalLdot,
+    };
+  };
+
+  const testHomaRouter = async (destAddr: string) => {
+    const relayerBal = await relayerAcalaFork.getBalance();
+    assert(relayerBal.gt(parseEther('10')), `relayer doesn't have enough balance to relay! ${relayerAcalaFork.address}`);
+
+    const routeArgs = {
+      destAddr,
+      chain: 'acala',
+    };
+    const res = await shouldRouteHoma(routeArgs);
+    ({ routerAddr } = res.data);
+
+    // make sure user has enough DOT to transfer to router
+    const bal = await fetchTokenBalances();
+    if (bal.userBalDot.lt(parsedStakeAmount)) {
+      if (bal.relayerBalDot.lt(parsedStakeAmount)) {
+        throw new Error('both relayer and user do not have enough DOT to transfer to router!');
+      }
+
+      console.log('refilling dot for user ...');
+      await (await dot.connect(relayerAcalaFork).transfer(TEST_ADDR_USER, parsedStakeAmount)).wait();
+    }
+
+    const bal0 = await fetchTokenBalances();
+
+    console.log('xcming to router ...');
+    await mockXcmToRouter(routerAddr, userAcalaFork, DOT, stakeAmount);
+
+    console.log('routing ...');
+    const routeRes = await routeHoma({
+      ...routeArgs,
+      token: DOT,
+    });
+    const txHash = routeRes.data;
+    console.log(`route finished! txHash: ${txHash}`);
+
+    const bal1 = await fetchTokenBalances();
+
+    // router should be destroyed
+    const routerCode = await providerAcalaFork.getCode(routerAddr);
+    expect(routerCode).to.eq('0x');
+    expect(bal1.routerBalDot.toNumber()).to.eq(0);
+    expect(bal1.routerBalLdot.toNumber()).to.eq(0);
+
+    // user should receive LDOT
+    const routingFee = await fee.getFee(DOT);
+    const exchangeRate = await homa.getExchangeRate();   // 10{18} LDOT => ? DOT
+    const expectedLdot = parsedStakeAmount.sub(routingFee).mul(ONE_ACA).div(exchangeRate);
+    const ldotReceived = bal1.userBalLdot.sub(bal0.userBalLdot);
+
+    expect(almostEq(expectedLdot, ldotReceived)).to.be.true;
+    expect(bal0.userBalDot.sub(bal1.userBalDot).toBigInt()).to.eq(parsedStakeAmount.toBigInt());
+
+    // relayer should receive DOT fee
+    expect(bal1.relayerBalDot.sub(bal0.relayerBalDot).toBigInt()).to.eq(routingFee.toBigInt());
+  };
+
+  const testAutoHomaRouter = async (destAddr: string) => {
+    const relayerBal = await relayerAcalaFork.getBalance();
+    assert(relayerBal.gt(parseEther('10')), `relayer doesn't have enough balance to relay! ${relayerAcalaFork.address}`);
+
+    const routeArgs = {
+      destAddr,
+      chain: 'acala',
+    };
+    const res = await shouldRouteHoma(routeArgs);
+    ({ routerAddr } = res.data);
+
+    // make sure user has enough DOT to transfer to router
+    const bal = await fetchTokenBalances();
+    if (bal.userBalDot.lt(parsedStakeAmount)) {
+      if (bal.relayerBalDot.lt(parsedStakeAmount)) {
+        throw new Error('both relayer and user do not have enough DOT to transfer to router!');
+      }
+
+      console.log('refilling dot for user ...');
+      await (await dot.connect(relayerAcalaFork).transfer(TEST_ADDR_USER, parsedStakeAmount)).wait();
+    }
+
+    const bal0 = await fetchTokenBalances();
+
+    console.log('sending auto routing request ...');
+    const routeRes = await routeHomaAuto({
+      ...routeArgs,
+      token: DOT,
+    });
+    const reqId = routeRes.data;
+    console.log(`auto route submitted! reqId: ${reqId}`);
+
+    const waitForRoute = new Promise<void>((resolve, reject) => {
+      const pollRouteStatus = setInterval(async () => {
+        const res = await routeStatus({ id: reqId });
+        // console.log(`current status: ${res.data.status}`);
+
+        if (res.data[0].status === RouteStatus.Complete) {
+          resolve();
+          clearInterval(pollRouteStatus);
+        }
+      }, 1000);
+
+      setTimeout(reject, 100 * 1000);
+    });
+
+    console.log('xcming to router ...');
+    await mockXcmToRouter(routerAddr, userAcalaFork, DOT, stakeAmount);
+
+    console.log('waiting for auto routing ...');
+    await waitForRoute;
+
+    console.log('route complete!');
+    const bal1 = await fetchTokenBalances();
+
+    // router should be destroyed
+    const routerCode = await providerAcalaFork.getCode(routerAddr);
+    expect(routerCode).to.eq('0x');
+    expect(bal1.routerBalDot.toNumber()).to.eq(0);
+    expect(bal1.routerBalLdot.toNumber()).to.eq(0);
+
+    // user should receive LDOT
+    const routingFee = await fee.getFee(DOT);
+    const exchangeRate = await homa.getExchangeRate();   // 10{18} LDOT => ? DOT
+    const expectedLdot = parsedStakeAmount.sub(routingFee).mul(ONE_ACA).div(exchangeRate);
+    const ldotReceived = bal1.userBalLdot.sub(bal0.userBalLdot);
+
+    expect(almostEq(expectedLdot, ldotReceived)).to.be.true;
+    expect(bal0.userBalDot.sub(bal1.userBalDot).toBigInt()).to.eq(parsedStakeAmount.toBigInt());
+
+    // relayer should receive DOT fee
+    expect(bal1.relayerBalDot.sub(bal0.relayerBalDot).toBigInt()).to.eq(routingFee.toBigInt());
+  };
+
+  it('route to evm address', async () => {
+    await testHomaRouter(TEST_ADDR_USER);
+  });
+
+  it('route to substrate address', async () => {
+    const ACALA_SS58_PREFIX = 10;
+    const userAccountId = await evmAccounts.getAccountId(TEST_ADDR_USER);
+    const userSubstrateAddr = encodeAddress(userAccountId, ACALA_SS58_PREFIX);
+
+    await testHomaRouter(userSubstrateAddr);
+  });
+
+  it('auto route to evm address', async () => {
+    await testAutoHomaRouter(TEST_ADDR_USER);
+  });
+
+  it('auto route to substrate address', async () => {
+    const ACALA_SS58_PREFIX = 10;
+    const userAccountId = await evmAccounts.getAccountId(TEST_ADDR_USER);
+    const userSubstrateAddr = encodeAddress(userAccountId, ACALA_SS58_PREFIX);
+
+    await testAutoHomaRouter(userSubstrateAddr);
+  });
+});

--- a/src/__tests__/routeHoma.test.ts
+++ b/src/__tests__/routeHoma.test.ts
@@ -31,7 +31,7 @@ const providerAcalaFork = new AcalaJsonRpcProvider(ETH_RPC.LOCAL);
 const relayerAcalaFork = new Wallet(TEST_KEY.RELAYER, providerAcalaFork);
 const userAcalaFork = new Wallet(TEST_KEY.USER, providerAcalaFork);
 
-describe.only('/routeHoma', () => {
+describe.skip('/routeHoma', () => {
   const DOT_DECIMALS = 10;
   const dot = ERC20__factory.connect(DOT, providerAcalaFork);
   const ldot = ERC20__factory.connect(LDOT, providerAcalaFork);

--- a/src/api/homa.ts
+++ b/src/api/homa.ts
@@ -68,15 +68,17 @@ export enum RouteStatus {
 };
 
 interface RouteInfo {
+  reqId: string;
   status: RouteStatus;
   destAddr: string;
+  routerAddr: string;
   timestamp: number;
   params: RouteParamsHoma;
   txHash?: string;
   err?: any;
 }
 
-type RouteTracker = Record<number, RouteInfo>;
+type RouteTracker = Record<string, RouteInfo>;
 
 const cleanUpTracker = (
   tracker: RouteTracker,
@@ -113,8 +115,10 @@ export const routeHomaAuto = async (params: RouteParamsHoma) =>  {
 
   const reqId = `homa-${routeReqId++}`;
   const tracker: RouteInfo = routeTracker[reqId] = {
+    reqId,
     status: RouteStatus.Waiting,
     destAddr,
+    routerAddr: routerAddr!,
     timestamp: Date.now(),
     params,
   };

--- a/src/api/homa.ts
+++ b/src/api/homa.ts
@@ -2,7 +2,6 @@ import { ContractTransaction } from 'ethers';
 import { DOT } from '@acala-network/contracts/utils/AcalaTokens';
 import { ERC20__factory, HomaFactory__factory } from '@acala-network/asset-router/dist/typechain-types';
 import { KSM } from '@acala-network/contracts/utils/KaruraTokens';
-import { ValidationError } from 'yup';
 
 import { DAY, MINUTE } from '../consts';
 import {
@@ -180,15 +179,13 @@ export const routeHomaAuto = async (params: RouteParamsHoma) =>  {
 };
 
 export const getRouteStatus = async ({ id, destAddr }: routeStatusParams): Promise<RouteInfo[]> => {
-  if (!id && !destAddr) {
-    throw new ValidationError('id or destAddr is required');
-  }
-
   if (id) {
     const routeInfo = routeTracker[id];
     return routeInfo ? [routeInfo] : [];
   } else {
-    return Object.values(routeTracker).filter(info => info.destAddr === destAddr);
+    return Object.values(routeTracker).filter(
+      info => info.destAddr.toLowerCase() === destAddr!.toLowerCase()
+    );
   }
 };
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -253,4 +253,9 @@ export const TESTNET_MODE_WARNING = `
 export const EUPHRATES_ADDR = '0x7Fe92EC600F15cD25253b421bc151c51b0276b7D';
 export const EUPHRATES_POOLS = ['0', '1', '2', '3'];
 
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+export const DAY = 24 * HOUR;
+
 export const VERSION = '1.7.0-0';

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,5 +1,5 @@
 import { CHAIN_ID_ACALA, CHAIN_ID_KARURA } from '@certusone/wormhole-sdk';
-import { ObjectSchema, mixed, object, string } from 'yup';
+import { ObjectSchema, mixed, number, object, string } from 'yup';
 
 export enum Mainnet {
   Acala = 'acala',
@@ -30,6 +30,7 @@ export interface RouteParamsXcm extends RouteParamsBase {
 export interface RouteParamsHoma {
   chain: Mainnet;
   destAddr: string;   // dest evm or acala native address
+  timeout?: number;   // timeout minutes
 }
 
 export interface RouteParamsEuphrates {
@@ -43,7 +44,8 @@ export interface RelayAndRouteParams extends RouteParamsXcm {
 }
 
 export interface routeStatusParams {
-  id: string;
+  id?: string;
+  destAddr?: string;
 }
 
 export const routeXcmSchema: ObjectSchema<RouteParamsXcm> = object({
@@ -69,6 +71,9 @@ export const routeWormholeSchema: ObjectSchema<RouteParamsWormhole> = object({
 export const routeHomaSchema: ObjectSchema<RouteParamsHoma> = object({
   destAddr: string().required(),
   chain: mixed<Mainnet>().oneOf(Object.values(Mainnet)).required(),
+  timeout: number()
+    .min(3, 'timeout must be at least 3 minutes')
+    .max(30, 'timeout cannot exceed 30 minutes'),
 });
 
 export const routeEuphratesSchema: ObjectSchema<RouteParamsEuphrates> = object({
@@ -78,5 +83,6 @@ export const routeEuphratesSchema: ObjectSchema<RouteParamsEuphrates> = object({
 });
 
 export const routeStatusSchema: ObjectSchema<routeStatusParams> = object({
-  id: string().required(),
+  id: string(),
+  destAddr: string(),
 });

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -85,4 +85,10 @@ export const routeEuphratesSchema: ObjectSchema<RouteParamsEuphrates> = object({
 export const routeStatusSchema: ObjectSchema<routeStatusParams> = object({
   id: string(),
   destAddr: string(),
-});
+}).test(
+  'id-or-destAddr',
+  'either `id` or `destAddr` is required',
+  value =>
+    (!!value.id && !value.destAddr) ||
+    (!value.id && !!value.destAddr)
+);


### PR DESCRIPTION
## Change
- added request params and other info to routeStatus for potential debugging convenience
- added optional `timeout` param to `/routeStatus`, to be more flexible
- added optional `destAddr` param to `/routeStatus`, so if user closes page and come back, UI can query user's recent route requests, and resume progress page (this is for frontend UX only, routing will continue in backend anyways)
- optimized tracker cleanup. It's not a good practice to have too many timeouts pending for 1 week, instead we can check tracker size, and do the cleanup when it reaches size limit
- moved route homa tests to it's only file

## Test
tested locally, auto routing still works, and new param also works