### PR TITLE
fix token in for swap and route

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,15 +509,12 @@ GET /shouldSwapAndRoute
 params: {
   poolId: string;         // euphrates pool id
   recipient: string;      // dest evm address
-  supplyAmount: string;   // swap tokenIn amount
-  targetToken?: string;   // swap tokenOut address, default: ACA address
-  targetAmount?: string;  // swap tokenOut amount (with erc20 decimals)
 }
 ```
 
 example
 ```
-GET /shouldSwapAndRoute?recipient=0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6&supplyAmount=100000000&poolId=7&targetToken=0x0000000000000000000100000000000000000000&targetAmount=2000000000000
+GET /shouldSwapAndRoute?recipient=0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6&poolId=7
 =>
 {
   "data": {
@@ -534,10 +531,7 @@ POST /swapAndRoute
 data: {
   poolId: string;         // euphrates pool id
   recipient: string;      // dest evm address
-  supplyAmount: string;   // swap tokenIn amount
   token?: string;         // token to route, not required for `shouldRoute`
-  targetToken?: string;   // swap tokenOut address, default: ACA address
-  targetAmount?: string;  // swap tokenOut amount (with erc20 decimals)
 }
 ```
 
@@ -545,11 +539,8 @@ example
 ```
 POST /swapAndRoute
 data: {
-  "recipient": "0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6",
-  "supplyAmount": 100000000,
   "poolId": 7,
-  "targetToken": "0x0000000000000000000100000000000000000000",
-  "targetAmount": 2000000000000,
+  "recipient": "0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6",
   "token": "0xa7fb00459f5896c3bd4df97870b44e868ae663d7"
 }
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -252,6 +252,9 @@ export const TESTNET_MODE_WARNING = `
 
 export const EUPHRATES_ADDR = '0x7Fe92EC600F15cD25253b421bc151c51b0276b7D';
 export const EUPHRATES_POOLS = ['0', '1', '2', '3', '7'];
+export const SWAP_SUPPLY_TOKENS = [
+  '0xa7fb00459f5896c3bd4df97870b44e868ae663d7',
+];
 
 export const RELAYER_ADDR = '0x8B5C2F71eFa2d88A20E0e1c8EDFeA3767B2ab230';
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -253,7 +253,7 @@ export const TESTNET_MODE_WARNING = `
 export const EUPHRATES_ADDR = '0x7Fe92EC600F15cD25253b421bc151c51b0276b7D';
 export const EUPHRATES_POOLS = ['0', '1', '2', '3', '7'];
 export const SWAP_SUPPLY_TOKENS = [
-  '0xa7fb00459f5896c3bd4df97870b44e868ae663d7',
+  '0xa7fb00459f5896c3bd4df97870b44e868ae663d7',   // jitosol
 ];
 
 export const RELAYER_ADDR = '0x8B5C2F71eFa2d88A20E0e1c8EDFeA3767B2ab230';

--- a/src/middlewares/router.ts
+++ b/src/middlewares/router.ts
@@ -2,6 +2,17 @@ import { NextFunction, Request, Response } from 'express';
 import { Schema } from 'yup';
 
 import {
+  NoRouteError,
+  logger,
+  relayAndRouteSchema,
+  routeEuphratesSchema,
+  routeHomaSchema,
+  routeStatusSchema,
+  routeWormholeSchema,
+  routeXcmSchema,
+  swapAndRouteSchema,
+} from '../utils';
+import {
   getAllRouteStatus,
   getRouteStatus,
   healthCheck,
@@ -17,17 +28,6 @@ import {
   shouldRouteWormhole,
   shouldRouteXcm,
 } from '../api';
-import {
-  relayAndRouteSchema,
-  routeEuphratesSchema,
-  routeHomaSchema,
-  routeWormholeSchema,
-  routeXcmSchema,
-  logger,
-  NoRouteError,
-  routeStatusSchema,
-  swapAndRouteSchema,
-} from '../utils';
 import { shouldSwapAndRoute, swapAndRoute } from '../api/swapAndRoute';
 
 interface RouterConfig {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -39,14 +39,8 @@ export interface RouteParamsEuphrates {
   token?: string;      // token to route, not required for `shouldRoute`
 }
 
-export interface SwapAndRouteParams {
-  poolId: string;         // euphrates pool id
-  recipient: string;      // dest evm address
-  supplyAmount: string;   // swap tokenIn amount
-  token?: string;         // token to route, not required for `shouldRoute`
-  targetToken?: string;   // swap tokenOut address, default: ACA address
-  targetAmount?: string;  // swap tokenOut amount (with erc20 decimals)
-}
+// does not support general swap yet
+export type SwapAndRouteParams = RouteParamsEuphrates;
 
 export interface RelayAndRouteParams extends RouteParamsXcm {
   signedVAA: string;
@@ -91,14 +85,7 @@ export const routeEuphratesSchema: ObjectSchema<RouteParamsEuphrates> = object({
   token: string(),
 });
 
-export const swapAndRouteSchema: ObjectSchema<SwapAndRouteParams> = object({
-  poolId: string().required(),
-  recipient: string().required(),
-  supplyAmount: string().required(),
-  token: string(),
-  targetToken: string(),
-  targetAmount: string(),
-});
+export const swapAndRouteSchema = routeEuphratesSchema;
 
 export const routeStatusSchema: ObjectSchema<routeStatusParams> = object({
   id: string(),


### PR DESCRIPTION
## Change
In order to prevent malicious user to construct a router with very small amount in and large amount out, we should not expose the params for token in.

So we just fix the params to swap ~0.5 USD jisotol to 3 ACA for now, according to our current use case.

## Test
manually tested locally with acala fork testnet, and worked

## Todo
In the future if we need a more general version where we expose these params, we need to add checks the make sure token in and token out amount are reasonable according to market price