### PR TITLE
relay polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ example
 ```
 # ---------- when should relay ---------- #
 GET /shouldRelay?originAsset=0x337610d27c682e347c9cd60bd4b3b107c9d34ddd&amount=10000000000000000000&targetChain=11
-=> {"shouldRelay":true,"msg":""}
+=> { "data": { "shouldRelay":true,"msg":"" } }
 
 # ---------- when should not relay ---------- #
 GET /shouldRelay?originAsset=0x337610d27c682e347c9cd60bd4b3b107c9d34ddd&amount=100000&targetChain=11

--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ example
 ```
 # ---------- when should relay ---------- #
 GET /shouldRelay?originAsset=0x337610d27c682e347c9cd60bd4b3b107c9d34ddd&amount=10000000000000000000&targetChain=11
-=> { "data": { "shouldRelay":true,"msg":"" } }
+=> {"data": { "shouldRelay":true,"msg":"" }}
 
 # ---------- when should not relay ---------- #
-GET /shouldRelay?originAsset=0x337610d27c682e347c9cd60bd4b3b107c9d34ddd&amount=100000&targetChain=11
-=> {"shouldRelay":false,"msg":"transfer amount too small, expect at least 10000000000000000"}
+GET /shouldRelay?targetChain=12&originAsset=J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn&amount=10000
+=> {"data":{"shouldRelay":false,"msg":"transfer amount too small, expect at least 1000000"}}
 
-GET /shouldRelay?originAsset=0x00000000000000000111111111111&amount=10000000000000000000&targetChain=11
-=> {"shouldRelay":false,"msg":"token not supported"}
+GET /shouldRelay?targetChain=12&originAsset=0x00000000000000000111111111111&amount=10000
+=> {"data":{"shouldRelay":false,"msg":"originAsset 0x00000000000000000111111111111 not supported"}}
 
-GET /shouldRelay?originAsset=0x337610d27c682e347c9cd60bd4b3b107c9d34ddd&amount=100000&targetChain=11
-=> {"shouldRelay":false,"msg":"target chain not supported"}
+GET shouldRelay?targetChain=3&originAsset=J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn&amount=10000000
+=> {"data":{"shouldRelay":false,"msg":"target chain 3 is not supported"}}
 ```
 ### `/relay`
 ask the relayer to relay a request, given the signedVAA

--- a/scripts/e2e-prod.ts
+++ b/scripts/e2e-prod.ts
@@ -8,14 +8,14 @@ import dotenv from 'dotenv';
 import path from 'path';
 
 import { BSC_TOKEN, ETH_RPC , RELAYER_URL } from '../src/consts';
-import { ROUTER_CHAIN_ID, getTokenBalance } from '../src/utils';
+import { RouterChainId, getTokenBalance } from '../src/utils';
 import { transferErc20, transferFromBSC } from './scriptUtils';
 
 dotenv.config({ path: path.join(__dirname, '.env') });
 const key = process.env.KEY;
 if (!key) throw new Error('KEY is not defined');
 
-const routeXcm = async (chainId: ROUTER_CHAIN_ID) => {
+const routeXcm = async (chainId: RouterChainId) => {
   console.log(`e2e testing routeXcm on ${CHAIN_ID_TO_NAME[chainId]}`);
   const params = chainId === CHAIN_ID_KARURA
     ? {
@@ -54,7 +54,7 @@ const routeXcm = async (chainId: ROUTER_CHAIN_ID) => {
   console.log(routeRes.data);
 };
 
-const routeWormhole = async (chainId: ROUTER_CHAIN_ID) => {
+const routeWormhole = async (chainId: RouterChainId) => {
   console.log(`e2e testing routeWormhole on ${CHAIN_ID_TO_NAME[chainId]}`);
   const originAddr = chainId === CHAIN_ID_KARURA
     ? ROUTER_TOKEN_INFO.usdc.originAddr

--- a/scripts/scriptUtils.ts
+++ b/scripts/scriptUtils.ts
@@ -4,7 +4,7 @@ import { ERC20__factory } from '@acala-network/asset-router/dist/typechain-types
 import { formatUnits, parseUnits } from 'ethers/lib/utils';
 
 import {
-  ROUTER_CHAIN_ID,
+  RouterChainId,
   bridgeToken,
   getSignedVAAFromSequence,
   parseAmount,
@@ -29,7 +29,7 @@ export const transferFromBSC = async (
   amount: string,
   sourceAsset: string,
   recipientAddr: string,
-  dstChainId: ROUTER_CHAIN_ID,
+  dstChainId: RouterChainId,
   wallet: Wallet,
   isMainnet = false,
 ): Promise<string> => {

--- a/src/__tests__/__snapshots__/shouldRelay.test.ts.snap
+++ b/src/__tests__/__snapshots__/shouldRelay.test.ts.snap
@@ -1,0 +1,99 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`/shouldRelay > when should relay 1`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 2`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 3`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 4`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 5`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 6`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 7`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 8`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 9`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 10`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 11`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 12`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 13`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;
+
+exports[`/shouldRelay > when should relay 14`] = `
+{
+  "msg": "",
+  "shouldRelay": true,
+}
+`;

--- a/src/api/relay.ts
+++ b/src/api/relay.ts
@@ -1,7 +1,7 @@
 import { TransactionReceipt } from '@ethersproject/providers';
 import { hexToUint8Array, tryHexToNativeString } from '@certusone/wormhole-sdk';
 
-import { RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS } from '../consts';
+import { RELAY_CONFIG } from '../consts';
 import {
   RelayError,
   RelayParams,
@@ -60,7 +60,7 @@ export const shouldRelay = async (params: ShouldRelayParams) => {
     return _noRelay(`failed to parse amount: ${_amount}`);
   }
 
-  const supported = RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS[targetChain];
+  const supported = RELAY_CONFIG[targetChain];
   if (!supported) {
     return _noRelay(`target chain ${targetChain} is not supported`);
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,13 +2,11 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 
+import { errorHandler, router } from './middlewares';
 import {
-  checkShouldRelay,
   getVersion,
-  relay,
   testTimeout,
 } from './api';
-import { errorHandler, router } from './middlewares';
 
 export const createApp = () => {
   const app = express();
@@ -18,8 +16,6 @@ export const createApp = () => {
   app.use(bodyParser.json());
 
   app.post('/testTimeout', testTimeout);
-  app.post('/relay', relay);
-  app.get('/shouldRelay', checkShouldRelay);
   app.get('/version', getVersion);
 
   app.use(router);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -142,8 +142,8 @@ const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_PROD = {
     // 1 karura WAUSD      => Acala AUSD 0x0000000000000000000100000000000000000001
     '0x0000000000000000000100000000000000000001': '100000000',   // 1 WAUSD = 10{8}
 
-    // 0.00000001 jitosol        => Acala jitosol 0xA7fB00459F5896C3bD4df97870b44e868Ae663D7
-    j1toso1uck3rlmjorhttrvwy9hj7x8v9yyac6y7kgcpn: '1',   // 1 jitosol = 10{9}
+    // 0.01 jitosol        => Acala jitosol 0xA7fB00459F5896C3bD4df97870b44e868Ae663D7
+    j1toso1uck3rlmjorhttrvwy9hj7x8v9yyac6y7kgcpn: '1000000',   // 1 jitosol = 10{9}
   },
 };
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -98,7 +98,7 @@ export const RELAYER_URL = {
    thredhold amount is defined as "amount that will show on VAA"
    address should be **lower case** address to be consistent
                                                 --------------- */
-const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_DEV = {
+const RELAY_CONFIG_DEV = {
   [CHAIN_ID_KARURA]: {
     // 0.1 BSC USDT => karura WUSDT 0x478dEFc2Fc2be13a505dafBDF1e5400847E2efF6
     '0x337610d27c682e347c9cd60bd4b3b107c9d34ddd': '10000000',
@@ -121,7 +121,7 @@ const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_DEV = {
   },
 };
 
-const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_PROD = {
+const RELAY_CONFIG_PROD = {
   [CHAIN_ID_KARURA]: {
     // 10 ETH mainnet USDC => karura WUSDC 0x1F3a10587A20114EA25Ba1b388EE2dD4A337ce27
     '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': '10000000',     // 1 USDC = 10{6}
@@ -147,9 +147,9 @@ const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_PROD = {
   },
 };
 
-export const RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS = isTestnet
-  ? RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_DEV
-  : RELAYER_SUPPORTED_ADDRESSES_AND_THRESHOLDS_PROD;
+export const RELAY_CONFIG = isTestnet
+  ? RELAY_CONFIG_DEV
+  : RELAY_CONFIG_PROD;
 
 export const enum PARA_ID {
   BASILISK = '2090',

--- a/src/middlewares/router.ts
+++ b/src/middlewares/router.ts
@@ -5,17 +5,20 @@ import {
   NoRouteError,
   logger,
   relayAndRouteSchema,
+  relaySchema,
   routeEuphratesSchema,
   routeHomaSchema,
   routeStatusSchema,
   routeWormholeSchema,
   routeXcmSchema,
+  shouldRelaySchema,
   swapAndRouteSchema,
 } from '../utils';
 import {
   getAllRouteStatus,
   getRouteStatus,
   healthCheck,
+  relay,
   relayAndRoute,
   relayAndRouteBatch,
   routeEuphrates,
@@ -23,6 +26,7 @@ import {
   routeHomaAuto,
   routeWormhole,
   routeXcm,
+  shouldRelay,
   shouldRouteEuphrates,
   shouldRouteHoma,
   shouldRouteWormhole,
@@ -41,6 +45,10 @@ const ROUTER_CONFIGS: {
   };
 } = {
   GET: {
+    '/shouldRelay': {
+      schema: shouldRelaySchema,
+      handler: shouldRelay,
+    },
     '/shouldRouteWormhole': {
       schema: routeWormholeSchema,
       handler: shouldRouteWormhole,
@@ -74,6 +82,10 @@ const ROUTER_CONFIGS: {
   },
 
   POST: {
+    '/relay': {
+      schema: relaySchema,
+      handler: relay,
+    },
     '/routeWormhole': {
       schema: routeWormholeSchema,
       handler: routeWormhole,

--- a/src/utils/configureEnv.ts
+++ b/src/utils/configureEnv.ts
@@ -6,10 +6,10 @@ import { Wallet } from 'ethers';
 import { bool, cleanEnv, str } from 'envalid';
 import dotenv from 'dotenv';
 
-import { ROUTER_CHAIN_ID, getApi } from './utils';
+import { RouterChainId, getApi } from './utils';
 
 export type ChainConfig = {
-  chainId: ROUTER_CHAIN_ID;
+  chainId: RouterChainId;
   provider: AcalaJsonRpcProvider;
   wallet: Wallet;
   api: ApiPromise;
@@ -92,6 +92,6 @@ const configAcala = async (): Promise<ChainConfig> => {
 };
 
 const configs = prepareEnvironment();
-export const getChainConfig = async (chainId: ROUTER_CHAIN_ID): Promise<ChainConfig> => (
+export const getChainConfig = async (chainId: RouterChainId): Promise<ChainConfig> => (
   (await configs).find(x => x.chainId === chainId)!
 );

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -12,10 +12,11 @@ import { options } from '@acala-network/api';
 
 import { RelayerError } from './error';
 import { bridgeToken, getSignedVAAFromSequence } from './wormhole';
-import { parseAmount } from './token';
 import { logger } from './logger';
+import { parseAmount } from './token';
 
-export type ROUTER_CHAIN_ID = typeof CHAIN_ID_KARURA | typeof CHAIN_ID_ACALA;
+export const ROUTER_CHAIN_IDS = [CHAIN_ID_KARURA, CHAIN_ID_ACALA] as const;
+export type RouterChainId = typeof ROUTER_CHAIN_IDS[number]
 
 export const getApi = async (privateKey: string, nodeUrl: string) => {
   await cryptoWaitReady();
@@ -36,7 +37,7 @@ export const transferFromAvax = async (
   amount: string,
   sourceAsset: string,
   recipientAddr: string,
-  dstChainId: ROUTER_CHAIN_ID,
+  dstChainId: RouterChainId,
   wallet: Wallet,
   isMainnet = false,
 ): Promise<string> => {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -64,7 +64,10 @@ export interface routeStatusParams {
 
 const ALL_WORMHOLE_CHAIN_IDS = Object.values(CHAINS);
 export const shouldRelaySchema: ObjectSchema<ShouldRelayParams> = object({
-  targetChain: mixed<ChainId>().oneOf(ALL_WORMHOLE_CHAIN_IDS).required(),
+  targetChain: mixed<ChainId>()
+    .transform((_, originalValue) => Number(originalValue))
+    .oneOf(ALL_WORMHOLE_CHAIN_IDS, 'targetChain is not a valid wormhole chain id')
+    .required(),
   originAsset: string().required(),
   amount: string().required(),
 });

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,4 +1,4 @@
-import { CHAIN_ID_ACALA, CHAIN_ID_KARURA } from '@certusone/wormhole-sdk';
+import { CHAINS, CHAIN_ID_ACALA, CHAIN_ID_KARURA, ChainId } from '@certusone/wormhole-sdk';
 import { ObjectSchema, mixed, number, object, string } from 'yup';
 
 export enum Mainnet {
@@ -11,6 +11,17 @@ export const getMainnetChainId = (mainnet: Mainnet) => (
     ? CHAIN_ID_ACALA
     : CHAIN_ID_KARURA
 );
+
+export interface ShouldRelayParams {
+  targetChain: ChainId;
+  originAsset: string;    // original address without padding 0s
+  amount: string;
+}
+
+export interface RelayParams {
+  targetChain: ChainId;
+  signedVAA: string;
+}
 
 interface RouteParamsBase {
   originAddr: string;     // origin token address
@@ -50,6 +61,18 @@ export interface routeStatusParams {
   id?: string;
   destAddr?: string;
 }
+
+const ALL_WORMHOLE_CHAIN_IDS = Object.values(CHAINS);
+export const shouldRelaySchema: ObjectSchema<ShouldRelayParams> = object({
+  targetChain: mixed<ChainId>().oneOf(ALL_WORMHOLE_CHAIN_IDS).required(),
+  originAsset: string().required(),
+  amount: string().required(),
+});
+
+export const relaySchema: ObjectSchema<RelayParams> = object({
+  targetChain: mixed<ChainId>().oneOf(ALL_WORMHOLE_CHAIN_IDS).required(),
+  signedVAA: string().required(),
+});
 
 export const routeXcmSchema: ObjectSchema<RouteParamsXcm> = object({
   originAddr: string().required(),


### PR DESCRIPTION
## Change
polished relay implementation, and moved the handling for `/shouldRelay` `/relay` to the unified router, which is more consistent with other endpoints. Result format is slightly changed to be consistent

## Test
- updated shouldRelay tests
- manually tests `/relay` endpoint still works